### PR TITLE
Update `oci_auth_refresher.sh` to support profile from environment var

### DIFF
--- a/.github/badges/downloads.json
+++ b/.github/badges/downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "downloads",
-  "message": "19",
+  "message": "20",
   "color": "blue"
 }

--- a/Formula/ocloud.rb
+++ b/Formula/ocloud.rb
@@ -5,12 +5,12 @@
 class Ocloud < Formula
   desc "Tool for finding and connecting to OCI instances"
   homepage "https://github.com/cnopslabs/ocloud"
-  version "0.0.4"
+  version "0.0.5"
   license "MIT"
 
   on_macos do
-    url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.4/ocloud_0.0.4_darwin_all.tar.gz"
-    sha256 "6454580d6dc81164ca1cd5a22caf0284d8bf28faafc72f9ed843bf445b5c9cc1"
+    url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.5/ocloud_0.0.5_darwin_all.tar.gz"
+    sha256 "cd468ca7363ae74f565cc6dfc90c9c7421938402589090440c7c03054d5cd6fa"
 
     def install
       bin.install "ocloud"
@@ -19,15 +19,15 @@ class Ocloud < Formula
 
   on_linux do
     if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
-      url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.4/ocloud_0.0.4_linux_amd64.tar.gz"
-      sha256 "2ac91366ba3f128b912557070dd1520950691d35b7a7d6d406ecf519e687bdc6"
+      url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.5/ocloud_0.0.5_linux_amd64.tar.gz"
+      sha256 "f1cc8daab0d6b903c11e74695c3fe148f3e718a1da2f7c051e17e75de31e34fe"
       def install
         bin.install "ocloud"
       end
     end
     if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
-      url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.4/ocloud_0.0.4_linux_arm64.tar.gz"
-      sha256 "811b0ad8f8177b82227621358ed660b09eb163a8c5a292e49e885c9ac797ace3"
+      url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.5/ocloud_0.0.5_linux_arm64.tar.gz"
+      sha256 "8fdbb1351f7f136a3279c84a742d3c8d6ea6d5360c2fdcc41d85f6d147925fb2"
       def install
         bin.install "ocloud"
       end

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OCloud - Oracle Cloud Infrastructure CLI Tool
 [![CI Build](https://github.com/cnopslabs/ocloud/actions/workflows/build.yml/badge.svg)](https://github.com/cnopslabs/ocloud/actions/workflows/build.yml)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/cnopslabs/ocloud?sort=semver)
-[![Downloads](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/cnopslabs/ocloud/main/.github/badges/downloads.json&style=flat&logo=github&logoColor=white&label=downloads&labelColor=2f363d&color=brightgreen&cacheSeconds=3600)](https://github.com/cnopslabs/releases)
+[![Downloads](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/cnopslabs/ocloud/main/.github/badges/downloads.json&style=flat&logo=github&logoColor=white&label=downloads&labelColor=2f363d&color=brightgreen&cacheSeconds=3600)](https://github.com/cnopslabs/ocloud/releases)
 [![Version](https://img.shields.io/badge/goversion-1.21.x-blue.svg)](https://golang.org)
 [![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/cnopslabs/ocloud/main/LICENSE.md)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cnopslabs/ocloud)](https://goreportcard.com/report/github.com/cnopslabs/ocloud)

--- a/scripts/oci_auth_refresher.sh
+++ b/scripts/oci_auth_refresher.sh
@@ -2,19 +2,21 @@
 # shellcheck shell=bash disable=SC1071
 
 # ───────────────────────────────────────────────────────────
-# oci_auth_refresher.sh  •  v0.1.1
+# oci_auth_refresher.sh  •  v0.1.2
 #
 # Keeps an OCI CLI session alive by refreshing it shortly
 # before it expires. Intended to be launched (nohup) from the
 # wrapper script oshell.sh.
 # ───────────────────────────────────────────────────────────
 
-# Check if profile argument is provided, use DEFAULT if not
-if [[ -z "$1" ]]; then
+# Check if profile argument is provided, then check environment variable, use DEFAULT if neither exists
+if [[ -n "$1" ]]; then
+  OCI_CLI_PROFILE=$1
+elif [[ -n "${OCI_CLI_PROFILE}" ]]; then
+  echo "Using profile from environment variable: ${OCI_CLI_PROFILE}"
+else
   echo "No profile name provided, using DEFAULT"
   OCI_CLI_PROFILE="DEFAULT"
-else
-  OCI_CLI_PROFILE=$1
 fi
 
 # Check if script is being run directly (not through nohup)


### PR DESCRIPTION
- Changed profile resolution logic to check the environment variable `OCI_CLI_PROFILE` when no argument is provided.
- Updated the script version to `v0.1.2`.