### PR TITLE
Prompt user before adding and saving tenancy map records

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Running `ocloud` without any arguments displays the configuration details and av
 ╚██████╔╝╚██████╗███████╗╚██████╔╝╚██████╔╝██████╔╝
  ╚═════╝  ╚═════╝╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝
 
-	      Version: 0.0.5
+	      Version: 0.0.6
 
 Configuration Details: Valid until 2025-08-02 23:26:28
   OCI_CLI_PROFILE: DEFAULT

--- a/internal/services/configuration/setup/service.go
+++ b/internal/services/configuration/setup/service.go
@@ -107,10 +107,19 @@ func (s *Service) ConfigureTenancyFile() (err error) {
 			Compartments: values["compartments"].([]string),
 			Regions:      values["regions"].([]string),
 		}
-		mappingFile = append(mappingFile, record)
-
-		more := strings.ToLower(prompt(reader, "Add another record? (y/n)"))
-		if more == "n" || more == "no" {
+		// Display a record before saving it to the file
+		fmt.Println("\t--- Record ---")
+		out, err := yaml.Marshal(record)
+		if err != nil {
+			return fmt.Errorf("marshalling tenancy map: %w", err)
+		}
+		fmt.Println(string(out))
+		if util.PromptYesNo("Do you want to add this record to the tenancy map?") {
+			mappingFile = append(mappingFile, record)
+		} else {
+			fmt.Println("Record discarded")
+		}
+		if !util.PromptYesNo("Do you want to add another record?") {
 			break
 		}
 	}


### PR DESCRIPTION
- Added confirmation prompt to review and approve each record before saving.
- Users can now discard records and decide whether to add new ones using improved prompts.