### PR TITLE
feat: support OCI profile-specific session validation

### DIFF
--- a/.github/badges/downloads.json
+++ b/.github/badges/downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "downloads",
-  "message": "35",
+  "message": "42",
   "color": "blue"
 }


### PR DESCRIPTION
- Update `CheckOCISessionValidity` to accept a profile argument.
- Validate session using the specified profile and handle unset profiles gracefully.
- Adjust `PrintOCIConfiguration` for improved profile detection and display.