### PR TITLE
feat: introduce `get` command for images and enhance TUI functionality

### DIFF
--- a/.github/badges/downloads.json
+++ b/.github/badges/downloads.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "downloads",
-  "message": "75",
+  "message": "80",
   "color": "blue"
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
       - "develop"
       - 'feature-*'
       - 'feature/*'
+      - 'refactor/*'
+      - 'refactor-*'
     paths-ignore:
       - 'README.md'
   pull_request:

--- a/Formula/ocloud.rb
+++ b/Formula/ocloud.rb
@@ -5,12 +5,12 @@
 class Ocloud < Formula
   desc "Tool for finding and connecting to OCI instances"
   homepage "https://github.com/cnopslabs/ocloud"
-  version "0.0.9"
+  version "0.0.10"
   license "MIT"
 
   on_macos do
-    url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.9/ocloud_0.0.9_darwin_all.tar.gz"
-    sha256 "d2db5a8d5d251b9b0fb98af96b2fee52e2cb3db7071c5fb451e9342b2bc41460"
+    url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.10/ocloud_0.0.10_darwin_all.tar.gz"
+    sha256 "f2837c3d81e9f757d9ccb341595f1266b2d01918bcfd2a5fe3c83d72bf9dde82"
 
     def install
       bin.install "ocloud"
@@ -19,15 +19,15 @@ class Ocloud < Formula
 
   on_linux do
     if Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
-      url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.9/ocloud_0.0.9_linux_amd64.tar.gz"
-      sha256 "37f51b3440e939cef37d4f26edc3814a3b3bb7c2fec51a47e678c4cd623a5e05"
+      url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.10/ocloud_0.0.10_linux_amd64.tar.gz"
+      sha256 "f2a6aa248dbb004dfd46c04790c504a2f3b50d499c802bd6b63620f7db8d0cfb"
       def install
         bin.install "ocloud"
       end
     end
     if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
-      url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.9/ocloud_0.0.9_linux_arm64.tar.gz"
-      sha256 "6264a6adb363082d704a647bc0fada5e69f409c0fbe91bca313f6aa0330a246a"
+      url "https://github.com/cnopslabs/ocloud/releases/download/v0.0.10/ocloud_0.0.10_linux_arm64.tar.gz"
+      sha256 "da525aa609e6bd12688cb9292941c8206ca0d56105ca4e5074c5997a5d5460e6"
       def install
         bin.install "ocloud"
       end

--- a/cmd/compute/image/get.go
+++ b/cmd/compute/image/get.go
@@ -1,0 +1,71 @@
+package image
+
+import (
+	paginationFlags "github.com/cnopslabs/ocloud/cmd/flags"
+	"github.com/cnopslabs/ocloud/internal/app"
+	"github.com/cnopslabs/ocloud/internal/config/flags"
+	"github.com/cnopslabs/ocloud/internal/logger"
+	"github.com/cnopslabs/ocloud/internal/services/compute/image"
+	"github.com/spf13/cobra"
+)
+
+// Dedicated documentation for the get command
+var listLong = `
+Get images in the specified compartment with pagination support.
+
+This command retrieves available images in the current compartment.
+By default, it shows basic image information such as name, ID, operating system, and launch mode.
+
+The output is paginated, with a default limit of 20 images per page. You can navigate
+through pages using the --page flag and control the number of images per page with
+the --limit flag.
+
+Additional Information:
+- Use --json (-j) to output the results in JSON format
+- The command shows all available images in the compartment
+`
+
+var listExamples = `
+  # Get images with default pagination (20 per page)
+  ocloud compute image get
+
+  # Get images with custom pagination (10 per page, page 2)
+  ocloud compute image get --limit 10 --page 2
+
+  # Get images and output in JSON format
+  ocloud compute image get --json
+
+  # Get images with custom pagination and JSON output
+  ocloud compute image get --limit 5 --page 3 --json
+`
+
+// NewGetCmd creates a new command for listing images
+func NewGetCmd(appCtx *app.ApplicationContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "get",
+		Short:         "Get all images",
+		Long:          listLong,
+		Example:       listExamples,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunGetCommand(cmd, appCtx)
+		},
+	}
+
+	paginationFlags.LimitFlag.Add(cmd)
+	paginationFlags.PageFlag.Add(cmd)
+
+	return cmd
+}
+
+// RunGetCommand handles the execution of the list command
+func RunGetCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
+
+	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
+	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
+	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
+
+	logger.LogWithLevel(logger.CmdLogger, 1, "Running image list command in", "compartment", appCtx.CompartmentName, "limit", limit, "page", page, "json", useJSON)
+	return image.GetImages(appCtx, limit, page, useJSON)
+}

--- a/cmd/compute/image/get_test.go
+++ b/cmd/compute/image/get_test.go
@@ -14,12 +14,11 @@ func TestListCommand(t *testing.T) {
 	appCtx := &app.ApplicationContext{}
 
 	// Create a new list command
-	cmd := NewListCmd(appCtx)
+	cmd := NewGetCmd(appCtx)
 
 	// Test that the list command is properly configured
-	assert.Equal(t, "list", cmd.Use)
-	assert.Equal(t, []string{"l"}, cmd.Aliases)
-	assert.Equal(t, "List all images", cmd.Short)
+	assert.Equal(t, "get", cmd.Use)
+	assert.Equal(t, "Get all images", cmd.Short)
 	assert.Equal(t, listLong, cmd.Long)
 	assert.Equal(t, listExamples, cmd.Example)
 	assert.True(t, cmd.SilenceUsage)

--- a/cmd/compute/image/list.go
+++ b/cmd/compute/image/list.go
@@ -1,51 +1,40 @@
 package image
 
 import (
-	paginationFlags "github.com/cnopslabs/ocloud/cmd/flags"
 	"github.com/cnopslabs/ocloud/internal/app"
-	"github.com/cnopslabs/ocloud/internal/config/flags"
 	"github.com/cnopslabs/ocloud/internal/logger"
 	"github.com/cnopslabs/ocloud/internal/services/compute/image"
 	"github.com/spf13/cobra"
 )
 
-var listLong = `
-List all images in the specified compartment with pagination support.
+// Dedicated documentation for the list command (separate from get)
+var listCmdLong = `
+Interactively browse and search images in the specified compartment using a TUI.
 
-This command displays information about available images in the current compartment.
-By default, it shows basic image information such as name, ID, operating system, and launch mode.
+This command launches a Bubble Tea-based terminal UI that loads available images and lets you:
+- Search/filter images as you type
+- Navigate the list
+- Select a single image to view its details
 
-The output is paginated, with a default limit of 20 images per page. You can navigate
-through pages using the --page flag and control the number of images per page with
-the --limit flag.
-
-Additional Information:
-- Use --json (-j) to output the results in JSON format
-- The command shows all available images in the compartment
+After you pick an image, the tool prints detailed information about the selected image.
 `
 
-var listExamples = `
-  # List all images with default pagination (20 per page)
+var listCmdExamples = `
+  # Launch the interactive image browser
   ocloud compute image list
 
-  # List images with custom pagination (10 per page, page 2)
-  ocloud compute image list --limit 10 --page 2
-
-  # List images and output in JSON format
-  ocloud compute image list --json
-
-  # List images with custom pagination and JSON output
-  ocloud compute image list --limit 5 --page 3 --json
+  # Use fuzzy search in the UI to quickly find what you need
+  ocloud compute image list
 `
 
 // NewListCmd creates a new command for listing images
 func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "list",
-		Aliases:       []string{"l"},
 		Short:         "List all images",
-		Long:          listLong,
-		Example:       listExamples,
+		Aliases:       []string{"l"},
+		Long:          listCmdLong,
+		Example:       listCmdExamples,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -53,19 +42,12 @@ func NewListCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		},
 	}
 
-	paginationFlags.LimitFlag.Add(cmd)
-	paginationFlags.PageFlag.Add(cmd)
-
 	return cmd
 }
 
-// RunListCommand handles the execution of the list command
+// RunListCommand executes the interactive TUI image lister
 func RunListCommand(cmd *cobra.Command, appCtx *app.ApplicationContext) error {
-
-	limit := flags.GetIntFlag(cmd, flags.FlagNameLimit, paginationFlags.FlagDefaultLimit)
-	page := flags.GetIntFlag(cmd, flags.FlagNamePage, paginationFlags.FlagDefaultPage)
-	useJSON := flags.GetBoolFlag(cmd, flags.FlagNameJSON, false)
-
-	logger.LogWithLevel(logger.CmdLogger, 1, "Running image list command in", "compartment", appCtx.CompartmentName, "limit", limit, "page", page, "json", useJSON)
-	return image.ListImages(appCtx, limit, page, useJSON)
+	ctx := cmd.Context()
+	logger.LogWithLevel(logger.CmdLogger, 1, "Running image list (TUI) command in", "compartment", appCtx.CompartmentName)
+	return image.ListImages(ctx, appCtx)
 }

--- a/cmd/compute/image/root.go
+++ b/cmd/compute/image/root.go
@@ -17,8 +17,9 @@ func NewImageCmd(appCtx *app.ApplicationContext) *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	cmd.AddCommand(NewListCmd(appCtx))
+	cmd.AddCommand(NewGetCmd(appCtx))
 	cmd.AddCommand(NewFindCmd(appCtx))
+	cmd.AddCommand(NewListCmd(appCtx))
 
 	return cmd
 }

--- a/cmd/compute/image/root_test.go
+++ b/cmd/compute/image/root_test.go
@@ -27,30 +27,39 @@ func TestImageCommand(t *testing.T) {
 	assert.True(t, cmd.SilenceErrors)
 	assert.Nil(t, cmd.RunE, "RunE should be nil since the root command now has subcommands")
 
-	// Test that the subcommands are added
+	// Test that the list subcommand is added and configured (TUI, no pagination flags)
 	listCmd := findSubCommand(cmd, "list")
 	assert.NotNil(t, listCmd, "list subcommand should be added")
 	assert.Equal(t, "List all images", listCmd.Short)
 	assert.NotNil(t, listCmd.RunE, "list subcommand should have a RunE function")
 
-	// Test that the list subcommand has the appropriate flags
-	limitFlag := listCmd.Flags().Lookup(flags.FlagNameLimit)
-	assert.NotNil(t, limitFlag, "limit flag should be added to list subcommand")
-	assert.Equal(t, flags.FlagShortLimit, limitFlag.Shorthand)
-	assert.Equal(t, flags.FlagDescLimit, limitFlag.Usage)
-
-	pageFlag := listCmd.Flags().Lookup(flags.FlagNamePage)
-	assert.NotNil(t, pageFlag, "page flag should be added to list subcommand")
-	assert.Equal(t, flags.FlagShortPage, pageFlag.Shorthand)
-	assert.Equal(t, flags.FlagDescPage, pageFlag.Usage)
-
-	// JSON flag is now a global flag, so it should not be in the local flags
+	// JSON flag is now a global flag, so it should not be in the local flags for list
 	jsonFlag := listCmd.Flags().Lookup(flags.FlagNameJSON)
 	assert.Nil(t, jsonFlag, "json flag should not be added as a local flag to list subcommand")
 
 	// But we should still be able to get its value using flags.GetBoolFlag
 	useJSON := flags.GetBoolFlag(listCmd, flags.FlagNameJSON, false)
 	assert.False(t, useJSON, "default value of json flag should be false")
+
+	// Test that the get subcommand is added and has pagination flags
+	getCmd := findSubCommand(cmd, "get")
+	assert.NotNil(t, getCmd, "get subcommand should be added")
+	assert.Equal(t, "Get all images", getCmd.Short)
+	assert.NotNil(t, getCmd.RunE, "get subcommand should have a RunE function")
+
+	limitFlag := getCmd.Flags().Lookup(flags.FlagNameLimit)
+	assert.NotNil(t, limitFlag, "limit flag should be added to get subcommand")
+	assert.Equal(t, flags.FlagShortLimit, limitFlag.Shorthand)
+	assert.Equal(t, flags.FlagDescLimit, limitFlag.Usage)
+
+	pageFlag := getCmd.Flags().Lookup(flags.FlagNamePage)
+	assert.NotNil(t, pageFlag, "page flag should be added to get subcommand")
+	assert.Equal(t, flags.FlagShortPage, pageFlag.Shorthand)
+	assert.Equal(t, flags.FlagDescPage, pageFlag.Usage)
+
+	// JSON flag is global, so it should not be in the local flags for get either
+	jsonFlagGet := getCmd.Flags().Lookup(flags.FlagNameJSON)
+	assert.Nil(t, jsonFlagGet, "json flag should not be added as a local flag to get subcommand")
 
 	// Test that the find subcommand is added
 	findCmd := findSubCommand(cmd, "find")

--- a/cmd/identity/compartment/list_test.go
+++ b/cmd/identity/compartment/list_test.go
@@ -36,6 +36,6 @@ func TestListCommand(t *testing.T) {
 	assert.Equal(t, "page", pageFlag.Name)
 	assert.Equal(t, "p", pageFlag.Shorthand)
 
-	// Note: The JSON flag is a global flag and is not directly added to the command in the list.go file.
+	// Note: The JSON flag is a global flag and is not directly added to the command in the get.go file.
 	// It's added at a higher level in the command hierarchy.
 }

--- a/cmd/network/subnet/list_test.go
+++ b/cmd/network/subnet/list_test.go
@@ -41,6 +41,6 @@ func TestListCommand(t *testing.T) {
 	assert.Equal(t, "sort", sortFlag.Name)
 	assert.Equal(t, "s", sortFlag.Shorthand)
 
-	// Note: The JSON flag is a global flag and is not directly added to the command in the list.go file.
+	// Note: The JSON flag is a global flag and is not directly added to the command in the get.go file.
 	// It's added at a higher level in the command hierarchy.
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -22,7 +22,6 @@ type VersionInfo struct {
 // This function was refactored to return *cobra.Command directly instead of *VersionInfo
 // to fix an issue with adding the command to the root command
 func NewVersionCommand() *cobra.Command {
-	// If appCtx is nil, use os.Stdout as the default writer
 	var writer io.Writer = os.Stdout
 
 	vc := &VersionInfo{

--- a/internal/services/compute/image/get.go
+++ b/internal/services/compute/image/get.go
@@ -1,0 +1,41 @@
+package image
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cnopslabs/ocloud/internal/app"
+	"github.com/cnopslabs/ocloud/internal/logger"
+	"github.com/cnopslabs/ocloud/internal/services/util"
+)
+
+// GetImages retrieves and displays a list of images, utilizing pagination, sorting, and optional JSON output.
+// It uses the application context for accessing configurations, logging, and output streams.
+func GetImages(appCtx *app.ApplicationContext, limit int, page int, useJSON bool) error {
+	logger.LogWithLevel(appCtx.Logger, 1, "ListImages", "limit", limit, "page", page, "json", useJSON)
+
+	service, err := NewService(appCtx)
+	if err != nil {
+		return fmt.Errorf("creating compute service: %w", err)
+	}
+
+	ctx := context.Background()
+	images, totalCount, nextPageToken, err := service.Get(ctx, limit, page)
+	if err != nil {
+		return fmt.Errorf("listing images: %w", err)
+	}
+
+	// Display image information with pagination details
+	err = PrintImagesInfo(images, appCtx, &util.PaginationInfo{
+		CurrentPage:   page,
+		TotalCount:    totalCount,
+		Limit:         limit,
+		NextPageToken: nextPageToken,
+	}, useJSON)
+
+	if err != nil {
+		return fmt.Errorf("printing image table: %w", err)
+	}
+
+	return nil
+}

--- a/internal/services/compute/image/get_simple_test.go
+++ b/internal/services/compute/image/get_simple_test.go
@@ -29,8 +29,7 @@ func TestListImagesSimple(t *testing.T) {
 		Stdout:          io.Discard, // Discard output to avoid cluttering the test output
 	}
 
-	err := ListImages(appCtx, 20, 1, false)
+	err := GetImages(appCtx, 20, 1, false)
 
-	// but if we did, we would expect no error
 	assert.NoError(t, err)
 }

--- a/internal/services/compute/image/list.go
+++ b/internal/services/compute/image/list.go
@@ -4,38 +4,43 @@ import (
 	"context"
 	"fmt"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cnopslabs/ocloud/internal/app"
-	"github.com/cnopslabs/ocloud/internal/logger"
-	"github.com/cnopslabs/ocloud/internal/services/util"
 )
 
-// ListImages lists image from the compute service with a provided limit, page, and JSON output option.
-// It uses the application context for configuration and logging.
-// Returns an error if the operation fails.
-func ListImages(appCtx *app.ApplicationContext, limit int, page int, useJSON bool) error {
-	logger.LogWithLevel(appCtx.Logger, 1, "ListImages", "limit", limit, "page", page, "json", useJSON)
+// ListImages lists all images in the given compartment, allowing the user to select one via a TUI and display its details.
+// It initializes required services, fetches images, processes user selection, and prints the chosen image information.
+func ListImages(ctx context.Context, appCtx *app.ApplicationContext) error {
 
 	service, err := NewService(appCtx)
 	if err != nil {
-		return fmt.Errorf("creating compute service: %w", err)
+		return fmt.Errorf("creating image service: %w", err)
+	}
+	images, err := service.fetchAllImages(ctx)
+
+	// TUI selection
+	im := NewImageListModelFancy(images)
+	ip := tea.NewProgram(im, tea.WithContext(ctx))
+	ires, err := ip.Run()
+	if err != nil {
+		return fmt.Errorf("image selection TUI: %w", err)
+	}
+	chosen, ok := ires.(ResourceListModel)
+	if !ok || chosen.Choice() == "" {
+		return err
 	}
 
-	ctx := context.Background()
-	images, totalCount, nextPageToken, err := service.List(ctx, limit, page)
-	if err != nil {
-		return fmt.Errorf("listing images: %w", err)
+	var img Image
+	for _, it := range images {
+		if it.ID == chosen.Choice() {
+			img = it
+			break
+		}
 	}
 
-	// Display image information with pagination details
-	err = PrintImagesInfo(images, appCtx, &util.PaginationInfo{
-		CurrentPage:   page,
-		TotalCount:    totalCount,
-		Limit:         limit,
-		NextPageToken: nextPageToken,
-	}, useJSON)
-
+	err = PrintImageInfo(img, appCtx)
 	if err != nil {
-		return fmt.Errorf("printing image table: %w", err)
+		return fmt.Errorf("printing image info: %w", err)
 	}
 
 	return nil

--- a/internal/services/compute/image/output.go
+++ b/internal/services/compute/image/output.go
@@ -45,3 +45,26 @@ func PrintImagesInfo(images []Image, appCtx *app.ApplicationContext, pagination 
 	util.LogPaginationInfo(pagination, appCtx)
 	return nil
 }
+
+func PrintImageInfo(image Image, appCtx *app.ApplicationContext) error {
+	p := printer.New(appCtx.Stdout)
+
+	imageData := map[string]string{
+		"ID":              image.ID,
+		"Name":            image.Name,
+		"Created":         image.CreatedAt.String(),
+		"ImageOSVersion":  image.ImageOSVersion,
+		"OperatingSystem": image.OperatingSystem,
+		"LunchMode":       image.LunchMode,
+	}
+
+	orderedKeys := []string{
+		"ID", "Name", "Created", "ImageName", "ImageOSVersion", "OperatingSystem", "LunchMode",
+	}
+
+	title := util.FormatColoredTitle(appCtx, image.Name)
+
+	p.PrintKeyValues(title, imageData, orderedKeys)
+
+	return nil
+}

--- a/internal/services/compute/image/service.go
+++ b/internal/services/compute/image/service.go
@@ -27,9 +27,9 @@ func NewService(appCtx *app.ApplicationContext) (*Service, error) {
 	}, nil
 }
 
-// List retrieves a paginated list of image with given limit and page number parameters.
+// Get retrieves a paginated list of image with given limit and page number parameters.
 // It returns the slice of image, total count, next page token, and an error if encountered.
-func (s *Service) List(ctx context.Context, limit, pageNum int) ([]Image, int, string, error) {
+func (s *Service) Get(ctx context.Context, limit, pageNum int) ([]Image, int, string, error) {
 	logger.LogWithLevel(s.logger, 3, "List() called with pagination parameters",
 		"limit", limit,
 		"pageNum", pageNum)

--- a/internal/services/compute/image/tui_types.go
+++ b/internal/services/compute/image/tui_types.go
@@ -1,0 +1,80 @@
+package image
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// resourceItem defines a resource item for a list.
+type resourceItem struct {
+	id, title, description string
+}
+
+func (i resourceItem) Title() string       { return i.title }
+func (i resourceItem) Description() string { return i.description }
+func (i resourceItem) FilterValue() string { return i.title + " " + i.description }
+
+// ResourceListModel defines a TUI model for displaying a list of resources.
+type ResourceListModel struct {
+	list   list.Model
+	choice string
+	keys   struct {
+		confirm key.Binding
+		quit    key.Binding
+	}
+}
+
+func (m ResourceListModel) Init() tea.Cmd { return nil }
+func (m ResourceListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.list.SetSize(msg.Width, msg.Height-2)
+	case tea.KeyMsg:
+		if key.Matches(msg, m.keys.quit) {
+			return m, tea.Quit
+		}
+		if key.Matches(msg, m.keys.confirm) {
+			if it, ok := m.list.SelectedItem().(resourceItem); ok {
+				m.choice = it.id
+			}
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m ResourceListModel) View() string   { return m.list.View() }
+func (m ResourceListModel) Choice() string { return m.choice }
+
+func newResourceList(title string, items []list.Item) ResourceListModel {
+	delegate := list.NewDefaultDelegate()
+	l := list.New(items, delegate, 0, 0)
+	l.Title = title
+	l.SetShowTitle(true)
+	l.SetShowHelp(true)
+	l.SetFilteringEnabled(true)
+	l.SetShowFilter(true)
+
+	rm := ResourceListModel{list: l}
+	rm.keys.confirm = key.NewBinding(key.WithKeys("enter"))
+	rm.keys.quit = key.NewBinding(key.WithKeys("q", "esc", "ctrl+c"))
+	return rm
+}
+
+// NewImageListModelFancy creates a ResourceListModel to display instances in a searchable and interactive list.
+// It transforms each instance into a resourceItem with its name, ID, and VCN name as attributes.
+func NewImageListModelFancy(images []Image) ResourceListModel {
+	items := make([]list.Item, 0, len(images))
+	for _, img := range images {
+		name := img.Name
+		desc := fmt.Sprintf("ImageOSVersion: %s", img.ImageOSVersion)
+		id := img.ID
+		items = append(items, resourceItem{id: id, title: name, description: desc})
+	}
+	return newResourceList("Images", items)
+}

--- a/internal/services/identity/bastion/list.go
+++ b/internal/services/identity/bastion/list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cnopslabs/ocloud/internal/logger"
 )
 
+// ListBastions retrieves a list of bastion hosts and displays their information, optionally in JSON format.
 func ListBastions(ctx context.Context, appCtx *app.ApplicationContext, useJSON bool) error {
 
 	logger.LogWithLevel(appCtx.Logger, 1, "Listing bastions")

--- a/internal/services/identity/bastion/output.go
+++ b/internal/services/identity/bastion/output.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cnopslabs/ocloud/internal/services/util"
 )
 
+// PrintBastionInfo displays bastion instances in a formatted table or JSON format.
 func PrintBastionInfo(bastions []Bastion, appCtx *app.ApplicationContext, useJSON bool) error {
 
 	p := printer.New(appCtx.Stdout)

--- a/internal/services/network/subnet/output_test.go
+++ b/internal/services/network/subnet/output_test.go
@@ -191,7 +191,7 @@ func TestPrintSubnetInfo(t *testing.T) {
 		},
 	}
 
-	// Create a buffer to capture output
+	// Create a buffer to capture the output
 	var buf bytes.Buffer
 
 	// Create an application context with the buffer as stdout

--- a/internal/services/util/helpers.go
+++ b/internal/services/util/helpers.go
@@ -104,7 +104,6 @@ func DefaultPublicSSHKey() []string {
 			continue
 		}
 		name := f.Name()
-		// Only show public keys by default
 		if strings.HasSuffix(name, ".pub") {
 			sshKeys = append(sshKeys, filepath.Join(sshDir, name))
 		}

--- a/internal/services/util/output.go
+++ b/internal/services/util/output.go
@@ -20,7 +20,6 @@ func MarshalDataToJSONResponse[T any](p *printer.Printer, items []T, pagination 
 
 // FormatColoredTitle builds a colorized title string with tenancy, compartment, and cluster.
 func FormatColoredTitle(appCtx *app.ApplicationContext, name string) string {
-	// Create the colored title using components from the app context.
 	coloredTenancy := text.Colors{text.FgMagenta}.Sprint(appCtx.TenancyName)
 	coloredCompartment := text.Colors{text.FgCyan}.Sprint(appCtx.CompartmentName)
 	coloredName := text.Colors{text.FgBlue}.Sprint(name)
@@ -47,7 +46,6 @@ func SplitTextByMaxWidth(text string) []string {
 	currentLine := parts[0]
 
 	for i := 1; i < len(parts); i++ {
-		// If adding the next part makes the line too long, start a new line
 		if len(currentLine)+len(parts[i])+1 > 30 {
 			result = append(result, currentLine)
 			currentLine = parts[i]

--- a/internal/services/util/output_test.go
+++ b/internal/services/util/output_test.go
@@ -120,6 +120,5 @@ func TestSplitTextByMaxWidth(t *testing.T) {
 	// Test with a string that has multiple spaces
 	multiSpaceString := "This   string   has   multiple   spaces"
 	result = SplitTextByMaxWidth(multiSpaceString)
-	// The function uses strings.Fields which normalizes spaces, but also splits by max width
 	assert.Equal(t, []string{"This string has multiple", "spaces"}, result, "String with multiple spaces should be normalized and split if needed")
 }

--- a/internal/services/util/search_util_test.go
+++ b/internal/services/util/search_util_test.go
@@ -137,8 +137,6 @@ func TestExtractTagValues(t *testing.T) {
 	}
 	result, err = ExtractTagValues(freeform, defined)
 	assert.NoError(t, err, "ExtractTagValues should not return an error with empty values")
-	// We can't use NotContains with an empty string because it would match the spaces between values
-	// Instead, we'll check that the result doesn't contain empty values by ensuring it doesn't have consecutive spaces
 	assert.NotContains(t, result, "  ", "ExtractTagValues should not have consecutive spaces (empty values)")
 	assert.Contains(t, result, "value2", "ExtractTagValues should include valid values")
 	assert.Contains(t, result, "value3", "ExtractTagValues should include valid values")

--- a/scripts/oci_auth_refresher.sh
+++ b/scripts/oci_auth_refresher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ───────────────────────────────────────────────────────────
-# oci_auth_refresher.sh  •  v0.2.1
+# oci_auth_refresher.sh  •  v0.2.2
 #
 # Keeps an OCI CLI session alive by refreshing it shortly
 # before it expires. Intended to be launched nohup
@@ -30,7 +30,7 @@ LOG_FILE="${SESSION_DIR}/refresher.log"
 
 mkdir -p "$SESSION_DIR"
 
-# Relaunch with nohup if needed
+# Relaunch with nohup
 if [[ -z "$NOHUP" && -t 1 ]]; then
   export NOHUP=1
   script_path="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
@@ -72,7 +72,7 @@ function to_epoch() {
 
 # Check remaining session duration
 function get_remaining_session_duration() {
-  if oci session validate --profile "$OCI_CLI_PROFILE" --local 2>&1; then
+  if oci session validate --profile "$OCI_CLI_PROFILE" --local >> "$LOG_FILE" 2>&1; then
     oci_session_status="valid"
     echo "$oci_session_status" > "$SESSION_STATUS_FILE"
 
@@ -126,7 +126,6 @@ function refresh_session() {
 oci_session_status="unknown"
 remaining_time=0
 
-# Main loop
 get_remaining_session_duration
 
 while [[ "$oci_session_status" == "valid" ]]; do

--- a/test_ocloud.sh
+++ b/test_ocloud.sh
@@ -94,12 +94,12 @@ print_header "Testing compute image command"
 run_command ./bin/ocloud compute image --help
 run_command ./bin/ocloud comp img --help
 
-# Test compute image list command
-print_header "Testing compute image list command"
-run_command ./bin/ocloud compute image list
-run_command ./bin/ocloud compute image list
-run_command ./bin/ocloud compute image list --limit 10 --page 1 --json
-run_command ./bin/ocloud compute image list -m 10 -p 1 -j
+# Test compute image get command
+print_header "Testing compute image get command"
+run_command ./bin/ocloud compute image get
+run_command ./bin/ocloud compute image get
+run_command ./bin/ocloud compute image get --limit 10 --page 1 --json
+run_command ./bin/ocloud compute image get -m 10 -p 1 -j
 run_command ./bin/ocloud comp img l
 
 # Test compute image find command


### PR DESCRIPTION
refactor: relocate and export network utilities, clean up unused code
    
    - Moved network utilities from `cmd/identity/bastion` to `internal/services/util` and updated references.
    - Exported `ExtractHostname` and `ResolveHostToIP` for broader usage.
    - Removed unused `sshConfig` function and related imports to streamline codebase.
    - Simplified comments for clarity and consistency.    
    - Renamed `ListImages` to `GetImages` for better alignment with CLI conventions.
    - Added a new `get` command for fetching paginated image details with JSON support.
    - Enhanced `list` command to include an interactive TUI for image selection.
    - Added utility for displaying detailed information about images in TUI and CLI out